### PR TITLE
Fixed dependency typos and conflicts

### DIFF
--- a/6-rag-task-agent/requirements.txt
+++ b/6-rag-task-agent/requirements.txt
@@ -1,5 +1,5 @@
 asana==5.0.7
-openai==1.10.0
+#openai==1.10.0
 python-dotenv==0.13.0
 langchain==0.2.6
 langchain-anthropic==0.1.16
@@ -9,4 +9,4 @@ langchain-openai==0.1.10
 langchain-chroma==0.1.2
 streamlit==1.36.0
 pdfminer.six==20240706
-ustructured[all-docs]
+unstructured[all-docs]


### PR DESCRIPTION
Fixed dependency typos and conflicts. One of the langchain libs will pull the appropriate version of openai lib, so comment out the openai line because. Otherwise, version conflict will result.